### PR TITLE
Create Github Workflow file to build on commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build macos
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          cd xmlsec
+          xcodebuild -project xmlsec.xcodeproj | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Do not know if you are interested by github workflow, close if not

 so I suggest to build on commit with this workflow

In result in Actions tabs we could see information about result, we could add "badge" in readme about status
<img width="1354" alt="Screenshot 2021-05-29 at 22 10 49" src="https://user-images.githubusercontent.com/59135882/120083686-c7074000-c0ca-11eb-9411-889590adcbf1.png">
build on window could be added I think (but I am not a specialist of visual)

and then each commit have its little green check if success or red cross if failed to build
<img width="744" alt="Screenshot 2021-05-29 at 22 10 59" src="https://user-images.githubusercontent.com/59135882/120083689-cbcbf400-c0ca-11eb-9d91-811d2311119d.png">


we could also make some code to attach file on release automatically
could be just an upload of file already builded (like you have)
or just builded one with command line like in this example
https://github.com/mesopelagique/SFSymbols/blob/main/.github/workflows/release.yml